### PR TITLE
[shrpx] read private key's passwd from a file

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -312,6 +312,7 @@ void fill_default_config()
   set_config_str(&mod_config()->host, "0.0.0.0");
   mod_config()->port = 3000;
   mod_config()->private_key_file = 0;
+  mod_config()->private_key_passwd = 0;
   mod_config()->cert_file = 0;
 
   // Read timeout for SPDY upstream connection
@@ -465,6 +466,11 @@ void print_help(std::ostream& out)
       << "                       linked OpenSSL is configured to load system\n"
       << "                       wide certificates, they are loaded\n"
       << "                       at startup regardless of this option.\n"
+      << "    --private-key-passwd-file=<FILEPATH>\n"
+      << "                       Path to file that contains password for the\n"
+      << "                       server's private key. If none is given and\n"
+      << "                       the private key is password protected it'll\n"
+      << "                       be requested interactively."
       << "\n"
       << "  SPDY:\n"
       << "    -c, --spdy-max-concurrent-streams=<NUM>\n"
@@ -566,6 +572,7 @@ int main(int argc, char **argv)
       {"cacert", required_argument, &flag, 19 },
       {"backend-ipv4", no_argument, &flag, 20 },
       {"backend-ipv6", no_argument, &flag, 21 },
+      {"private-key-passwd-file", required_argument, &flag, 22},
       {0, 0, 0, 0 }
     };
     int option_index = 0;
@@ -702,6 +709,11 @@ int main(int argc, char **argv)
       case 21:
         // --backend-ipv6
         cmdcfgs.push_back(std::make_pair(SHRPX_OPT_BACKEND_IPV6, "yes"));
+        break;
+      case 22:
+        // --private-key-passwd-file
+        cmdcfgs.push_back(std::make_pair(SHRPX_OPT_PRIVATE_KEY_PASSWD_FILE,
+                                         optarg));
         break;
       default:
         break;

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -36,6 +36,7 @@
 namespace shrpx {
 
 extern const char SHRPX_OPT_PRIVATE_KEY_FILE[];
+extern const char SHRPX_OPT_PRIVATE_KEY_PASSWD_FILE[];
 extern const char SHRPX_OPT_CERTIFICATE_FILE[];
 
 extern const char SHRPX_OPT_BACKEND[];
@@ -81,6 +82,7 @@ struct Config {
   char *host;
   uint16_t port;
   char *private_key_file;
+  char *private_key_passwd;
   char *cert_file;
   bool verify_client;
   const char *server_name;
@@ -135,6 +137,9 @@ int parse_config(const char *opt, const char *optarg);
 // allocated Config object. This function returns 0 if it succeeds, or
 // -1.
 int load_config(const char *filename);
+
+// Read passwd from |filename|
+std::string read_passwd_from_file(const char *filename);
 
 // Copies NULL-terminated string |val| to |*destp|. If |*destp| is not
 // NULL, it is freed before copying.


### PR DESCRIPTION
This avoids the need to provide the password for your
private key interactively.

It can be used via --passwd-key-file or passwd-key-file
in the given config file. The first line in the file
(without \n) will be treated as the passwd. There isn't
any validation and all lines after the first one (if any)
are ignored.

The security model behind this is a bit simplistic so I
am open to better ideas. Basically your password file
should be root:root (400) and you _should_ drop root
and run as an unprivileged user.

If the file exists and a line can be read then a callback
will be set for the SSL ctxt and it'll feed the passwd
when the private key is read (if password is needed).
