### PR TITLE
spdycat: cannot read post data from /dev/stdin

### DIFF
--- a/src/spdycat.cc
+++ b/src/spdycat.cc
@@ -799,6 +799,9 @@ ssize_t file_read_callback
   ssize_t r;
   while((r = pread(fd, buf, length, req->data_offset)) == -1 &&
         errno == EINTR);
+  if (r == -1 && errno == ESPIPE) {
+    while((r = read(fd, buf, length)) == -1 && errno == EINTR);
+  }
   if(r == -1) {
     return SPDYLAY_ERR_TEMPORAL_CALLBACK_FAILURE;
   } else {


### PR DESCRIPTION
Reproduce:
    $ echo hello | spdycat -2 -v -d - https://localhost:443/test_post
    ...
    [  0.006] send RST_STREAM frame <version=2, flags=0, length=8>
              (stream_id=1, status_code=6)
    ...

  Error occurs when spdycat reads post data from /dev/stdin, in which case
  spdycat will send RST_STREAM(status_code=6(internal error)) to server.

Reason:
  In spdycat.cc, file_read_callback() use pread() to read post data.
  If post data file is /dev/stdin (pipe, socket or FIFO), pread() will
  returns -1 and set errno to ESPIPE.
  pread() is based on lseek(), but lseek() cannot works with pipe,
  socket or FIFO file.