### PR TITLE
docs: fix simple typo, thier -> their

### DIFF
--- a/lib/spdylay_frame.h
+++ b/lib/spdylay_frame.h
@@ -493,7 +493,7 @@ int spdylay_frame_unpack_settings(spdylay_settings *frame,
  * |len_size| is the number of bytes in length of name/value pair and
  * it must be 2 or 4.
  *
- * This function can handles duplicate keys and concatenation of thier
+ * This function can handles duplicate keys and concatenation of their
  * values with '\0'.
  */
 size_t spdylay_frame_count_nv_space(char **nv, size_t len_size);


### PR DESCRIPTION
There is a small typo in lib/spdylay_frame.h.

Should read `their` rather than `thier`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md